### PR TITLE
Slight modifications: less required vars, ansible syntax adapted. Tes…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,25 +9,25 @@ tool.
 Requirements
 ------------
 
-Ansible 1.6.x
+Ansible 1.9.x
 
 Tested on
 ---------
 
-1.9.2
+2.2.2.0
 
 Role Variables
 --------------
 
-* "perl_version" is used to specify the default perl version. Note: This cannot be `latest`, but need to be something like `perl-5.22.0`. The default will be changed to the latest stable.
+* "perl_version" is used to specify the default perl version. Note: This cannot be `latest`, but need to be something like `perl-5.26.1`. The default will be changed to the latest stable.
 * "perlbrew_user" is used to specify which user on the remote system that will get perlbrew.
 * "switch_to_new_perl" is used to activate (`perlbrew switch`) the new perl_version right away, default is `true` (if `false` added lines in `.profile`/`.bashrc` will be commented)
-* "perlbrew_as" name of the perlbrew namespace
+* "perlbrew_as" name of the perlbrew namespace, default is perl_version
 
 Example config:
 
     ---
-    perl_version: perl-5.22.0
+    perl_version: perl-5.26.1
     perlbrew_user: www
     switch_to_new_perl: true
     perlbrew_as: myperl
@@ -41,8 +41,21 @@ Including an example of how to use your role (for instance, with variables passe
       roles:
         - role: perlbrew 
           perlbrew_user: tobybro
-          perl_version: perl-5.22.0
+          perl_version: perl-5.26.1
           perlbrew_as: myawesomeperl
+
+Vagrant
+-------
+
+For testing the role in a virtual machine a 'Vagrantfile' and 'vagrant-inventory' file is provided (vagrantfiles for short). 
+You need Vagrant installed to use it. It is assumed that there is a user vagrant in the vm.
+
+Inside the directory of these two files say:
+- 'vagrant up' to set up the virtual machine and run the test, i.e. running the playbook in ./tests/playbook.yml
+- 'vagrant destroy' to delete the virtual machine
+
+A CentOS-7.4 is used for the test. Ubuntu is prepared in the vagrantfiles. Adapt it to your needs.
+
 
 License
 -------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,43 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure('2') do |config|
+
+  # Ensure we use our vagrant private key
+  config.ssh.insert_key = false
+  config.ssh.private_key_path = '~/.vagrant.d/insecure_private_key'
+
+#  config.vm.define 'ubuntu-vm' do |machine|
+#    machine.vm.box = "bento/ubuntu-16.04"
+#
+#    machine.vm.network :private_network, ip: '192.168.88.22'
+#    machine.vm.hostname = 'ubuntu-vm'
+#
+#    machine.vm.provision 'ansible' do |ansible|
+#      ansible.verbose = 'v'
+#      ansible.playbook = 'tests/playbook.yml'
+#      ansible.sudo = true
+#      ansible.inventory_path = 'vagrant-inventory'
+#      ansible.host_key_checking = false
+#    end
+#
+#  end
+
+  config.vm.define 'centos-vm' do |machine|
+    machine.vm.box = "bento/centos-7.4"
+
+    machine.vm.network :private_network, ip: '192.168.88.33'
+
+    # machine.vm.network "forwarded_port", guest: 22,  host: 11222, id: 'ssh'
+    machine.vm.hostname = 'centos-vm'
+
+    machine.vm.provision 'ansible' do |ansible|
+      #ansible.verbose = 'v'
+      ansible.playbook = 'tests/playbook.yml'
+      ansible.sudo = true
+      ansible.inventory_path = 'vagrant-inventory'
+      ansible.host_key_checking = false
+    end
+
+  end
+end

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-perlbrew_user: www
-perl_version: perl-5.22.0
+perlbrew_user: vagrant
+perl_version: perl-5.26.1
 perlbrew_root: ~/perl5/perlbrew
 switch_to_new_perl: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,7 @@
   - tar
   - patch
   - unzip
-  sudo: yes
+  become: yes
   when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
   tags: [ perlbrew, prereq ]
 
@@ -27,18 +27,18 @@
   - tar
   - patch
   - unzip
-  sudo: yes
+  become: yes
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
 
 - name: Make PERLBREW_ROOT
   file: path='{{ perlbrew_root }}' owner='{{ perlbrew_user }}' mode=0755 state=directory
-  sudo: yes
-  sudo_user: '{{ perlbrew_user }}'
+  become: yes
+  become_user: '{{ perlbrew_user }}'
   tags: [ perlbrew ]
 
 - name: Install perlbrew
-  sudo: yes
-  sudo_user: '{{ perlbrew_user }}'
+  become: yes
+  become_user: '{{ perlbrew_user }}'
   shell: curl -L http://install.perlbrew.pl | bash creates="{{ perlbrew_root }}/bin/perlbrew"
   register: install_perlbrew
   tags: [ perlbrew ]
@@ -49,12 +49,12 @@
 
 - name: Make sure ~/.bashrc exists
   file: path='~{{ perlbrew_user }}/.bashrc' state=touch mode=0644 force=no
-  sudo: yes
-  sudo_user: '{{ perlbrew_user }}'
+  become: yes
+  become_user: '{{ perlbrew_user }}'
 
 - name: Init ~/.bashrc
-  sudo: yes
-  sudo_user: '{{ perlbrew_user }}'
+  become: yes
+  become_user: '{{ perlbrew_user }}'
   lineinfile: dest='{{ item.dest }}' line='{{ item.line }}'
   with_items:
   - { dest: '~{{ perlbrew_user }}/.bashrc', line: 'export PERLBREW_ROOT={{ perlbrew_root }}' }
@@ -63,25 +63,25 @@
   tags: [ perlbrew, bashrc ]
 
 - name: Install {{ perl_version }} (may take some time...)
-  sudo: yes
-  sudo_user: '{{ perlbrew_user }}'
-  shell: "{{ perlbrew_bin }} install {{ perl_version }} --as {{ perlbrew_as }} --notest -Duseshrplib --force creates='{{ perlbrew_root }}/perls/{{ perlbrew_as }}'"
+  become: yes
+  become_user: '{{ perlbrew_user }}'
+  shell: "{{ perlbrew_bin }} install {{ perl_version }} --as {{ perlbrew_as | default(perl_version) }} --notest -Duseshrplib --force creates='{{ perlbrew_root }}/perls/{{ perlbrew_as | default(perl_version) }}'"
   register: perlbrew_build_output
   tags: [ perlbrew ]
 
 - name: Fail if Perl not installed correctly
   fail: msg="Perlbrew could not build Perl. Check the build log"
-  when: "perlbrew_build_output.changed == True and  perlbrew_as + ' is successfully installed.' not in perlbrew_build_output.stdout_lines"
+  when: "perlbrew_build_output.changed == True and  perlbrew_as | default(perl_version) + ' is successfully installed.' not in perlbrew_build_output.stdout_lines"
 
 - name: Install cpanm
-  sudo: yes
-  sudo_user: '{{ perlbrew_user }}'
+  become: yes
+  become_user: '{{ perlbrew_user }}'
   shell: "{{ perlbrew_bin }} install-cpanm creates='{{ perlbrew_root }}/bin/cpanm'"
   tags: [ perlbrew ]
 
 - name: Use Perl {{ perl_version }}
-  sudo: yes
-  sudo_user: '{{ perlbrew_user }}'
-  shell: PERLBREW_BASHRC_VERSION=1 {{ perlbrew_bin }} switch {{ perlbrew_as }}
+  become: yes
+  become_user: '{{ perlbrew_user }}'
+  shell: PERLBREW_BASHRC_VERSION=1 {{ perlbrew_bin }} switch {{ perlbrew_as | default(perl_version) }}
   when: switch_to_new_perl
   tags: [ perlbrew ]

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -1,0 +1,13 @@
+---
+
+- hosts: all
+  remote_user: root
+  become: yes
+  vars_files:
+    - ./vars.yml
+  roles:
+    # it is the directory relative to your current working directory under which the role files are located
+    # ./ does not work - why ?
+    - role: ../tobybro.perlbrew
+      perl_user: vagrant
+      perl_version: perl-5.26.1

--- a/vagrant-inventory
+++ b/vagrant-inventory
@@ -1,0 +1,2 @@
+#ubuntu-vm ansible_ssh_host=192.168.88.22 ansible_ssh_port=22 ansible_ssh_user=vagrant ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key
+centos-vm ansible_ssh_host=192.168.88.33 ansible_ssh_port=22 ansible_ssh_user=vagrant ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key


### PR DESCRIPTION
Hi Toby, 

hope you find my adaptions useful:

- replaced sudo/sudo_user by become/become_user
- variable perlbrew_as now optional, default is perlbrew_version (perlbrew standard)
- added Vagrantfile and tests/ to run the role in a virtual machine by vagrant
- required now ansible version 1.9.x, tested on ansible 2.2.2.0 with CentOS-7.4