### PR TITLE
Update so that Ubuntu distributions that have an out of date APT cach…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *swp
 /local
+/.vagrant

--- a/README.md
+++ b/README.md
@@ -44,7 +44,23 @@ Including an example of how to use your role (for instance, with variables passe
           perl_version: perl-5.26.1
           perlbrew_as: myawesomeperl
 
-Vagrant
+If you are using Ubuntu, you may want to add this to the beginning of your playbook to have it update your Ubuntu before trying to install, this could save you grief:
+
+#---
+#- hosts: all
+#  become: yes
+#
+  pre_tasks:
+  - name: Update cache before we get into anything
+    apt:
+      state: latest
+      force_apt_get: true
+      update_cache: true
+      cache_valid_time: 3600
+    become: yes
+    when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+
+[Vagrant](Vagrant)
 -------
 
 For testing the role in a virtual machine a 'Vagrantfile' and 'vagrant-inventory' file is provided (vagrantfiles for short). 

--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ Including an example of how to use your role (for instance, with variables passe
 
 If you are using Ubuntu, you may want to add this to the beginning of your playbook to have it update your Ubuntu before trying to install, this could save you grief:
 
-#---
-#- hosts: all
-#  become: yes
-#
+~~~yaml
+---
+- hosts: all
+  become: yes
+
   pre_tasks:
   - name: Update cache before we get into anything
     apt:
@@ -59,6 +60,7 @@ If you are using Ubuntu, you may want to add this to the beginning of your playb
       cache_valid_time: 3600
     become: yes
     when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+~~~
 
 [Vagrant](Vagrant)
 -------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,8 +9,8 @@ Vagrant.configure('2') do |config|
 
   config.vm.define 'perlbrew-vm' do |machine|
     machine.vm.box = "bento/centos-7.4"
-# machine.vm.box = "bento/ubuntu-16.04"
-# machine.vm.box = "bento/ubuntu-20.04"
+    # machine.vm.box = "bento/ubuntu-16.04"
+    # machine.vm.box = "bento/ubuntu-20.04"
 
     machine.vm.network :private_network, ip: '192.168.88.22'
     machine.vm.hostname = 'perlbrew-vm'
@@ -18,7 +18,7 @@ Vagrant.configure('2') do |config|
     machine.vm.provision 'ansible' do |ansible|
       ansible.verbose = 'v'
       ansible.playbook = 'tests/playbook.yml'
-      ansible.sudo = true
+      ansible.become = true
       ansible.inventory_path = 'vagrant-inventory'
       ansible.host_key_checking = false
     end

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,24 +31,63 @@
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
   tags: [ perlbrew, prereq ]
 
+- name: Expand perlbrew_root variable {{ perlbrew_root }}
+  environment:
+    PERLBREW_ROOT: '{{ perlbrew_root }}'
+  command: echo {{ perlbrew_root }}
+  register: command_result
+  become: yes
+  become_user: '{{ perlbrew_user }}'
+  tags: [ perlbrew ]
+
+- name: Set expanded perlbrew_root variable
+  set_fact:
+    perlbrew_root_expanded: '{{ command_result.stdout }}'
+  tags: [ perlbrew ]
+
 - name: Make PERLBREW_ROOT
-  file: path='{{ perlbrew_root }}' owner='{{ perlbrew_user }}' mode=0755 state=directory
+  file: 
+    path: '{{ perlbrew_root_expanded }}' 
+    owner: '{{ perlbrew_user }}' 
+    mode: 0755 
+    state: directory
   become: yes
   become_user: '{{ perlbrew_user }}'
   tags: [ perlbrew ]
 
-- name: Install perlbrew
+- name: 'Download Perlbrew {{ perlbrew.install_script_url }}'
+  environment:
+    http_proxy: '{{proxy_env.http_proxy | default ("") }}'
+    https_proxy: '{{proxy_env.https_proxy | default ("") }}'
+    no_proxy:    '{{proxy_env.no_proxy | default ("") }}'
+  get_url: 
+    url: '{{ perlbrew.install_script_url | default ("http://install.perlbrew.pl") }}'
+    dest: /tmp/perlbrew_install_script 
+    force: True
+    mode: "0755"
   become: yes
   become_user: '{{ perlbrew_user }}'
-  shell: curl -L http://install.perlbrew.pl | bash creates="{{ perlbrew_root }}/bin/perlbrew"
-  register: install_perlbrew
+  tags:
+  - perlbrew
+
+- name: Run Perlbrew install {{ perlbrew.install_script_url }}
+  environment:
+    http_proxy:  '{{proxy_env.http_proxy | default ("") }}'
+    https_proxy: '{{proxy_env.https_proxy | default ("") }}'
+    no_proxy:    '{{proxy_env.no_proxy | default ("") }}'
+    PERLBREW_ROOT: '{{ perlbrew_root_expanded }}'
+  command: /tmp/perlbrew_install_script
+  register: command_result
+  become: yes
+  become_user: '{{ perlbrew_user }}'
+  args:
+    chdir: /tmp/
   tags: [ perlbrew ]
 
-#    perlbrew_bin: PERLBREW_ROOT={{ perlbrew_root }} {{ perlbrew_root}}/bin/perlbrew
-#    perlbrew_bin: {{ perlbrew_root}}/bin/perlbrew
-- set_fact:
-    perlbrew_bin: "{{ perlbrew_root}}/bin/perlbrew"
-  tags: [ perlbrew ]
+-  name: Set Perlbrew bin directory
+   set_fact:
+     perlbrew_bin: '{{ perlbrew_root_expanded}}/bin/perlbrew'
+   tags: [ perlbrew ]
 
 - name: Make sure ~/.bashrc exists
   file: path='~{{ perlbrew_user }}/.bashrc' state=touch mode=0644 force=no
@@ -58,7 +97,9 @@
 - name: Init ~/.bashrc
   become: yes
   become_user: '{{ perlbrew_user }}'
-  lineinfile: dest='{{ item.dest }}' line='{{ item.line }}'
+  lineinfile: 
+    dest: '{{ item.dest }}' 
+    line: '{{ item.line }}'
   with_items:
   - { dest: '~{{ perlbrew_user }}/.bashrc', line: 'export PERLBREW_ROOT={{ perlbrew_root }}' }
   - { dest: '~{{ perlbrew_user }}/.bashrc', line: '. ${PERLBREW_ROOT}/etc/bashrc' }
@@ -67,24 +108,36 @@
 
 
 - name: Show perl version requested
-  debug: msg="installing {{ perl_version }}"
+  debug: 
+    msg: "installing {{ perl_version }}"
 
-- name: Install PERL_VERSION (may take some time...)
+- name: Install {{ perl_version }} (may take some time...)
+  environment:
+    http_proxy:  '{{proxy_env.http_proxy | default ("") }}'
+    https_proxy: '{{proxy_env.https_proxy | default ("") }}'
+    no_proxy:    '{{proxy_env.no_proxy | default ("") }}'
+    PERLBREW_ROOT: '{{ perlbrew_root_expanded }}'
   become: yes
   become_user: '{{ perlbrew_user }}'
-  shell: "{{ perlbrew_bin }} install {{ perl_version }} --as {{ perlbrew_as | default(perl_version) }} --notest -Duseshrplib --force creates='{{ perlbrew_root }}/perls/{{ perlbrew_as | default(perl_version) }}'"
-  register: perlbrew_build_output
+  command: "{{ perlbrew_bin }} install {{ perl_version }} --as {{ perlbrew_as | default(perl_version) }} --notest -Duseshrplib --force creates='{{ perlbrew_root }}/perls/{{ perlbrew_as | default(perl_version) }}'"
+  register: command_result
   tags: [ perlbrew ]
 
 - name: Fail if Perl not installed correctly
-  fail: msg="Perlbrew could not build Perl. Check the build log"
-  when: "perlbrew_build_output.changed == True and  perlbrew_as | default(perl_version) + ' is successfully installed.' not in perlbrew_build_output.stdout_lines"
+  fail:
+    msg: "Perlbrew could not build Perl. Check the build log"
+  when: "command_result.changed == True and  perlbrew_as | default(perl_version) + ' is successfully installed.' not in command_result.stdout"
   tags: [ perlbrew ]
 
 - name: Install cpanm
+  environment:
+    http_proxy:  '{{proxy_env.http_proxy | default ("") }}'
+    https_proxy: '{{proxy_env.https_proxy | default ("") }}'
+    no_proxy:    '{{proxy_env.no_proxy | default ("") }}'
+    PERLBREW_ROOT: '{{ perlbrew_root_expanded }}'
   become: yes
   become_user: '{{ perlbrew_user }}'
-  shell: "{{ perlbrew_bin }} install-cpanm creates='{{ perlbrew_root }}/bin/cpanm'"
+  command: "{{ perlbrew_bin }} install-cpanm creates='{{ perlbrew_root }}/bin/cpanm'"
   tags: [ perlbrew ]
 
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,7 @@
     - unzip
   become: yes
   when: ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
+  tags: [ perlbrew, prereq ]
 
 - name: Make PERLBREW_ROOT
   file: path='{{ perlbrew_root }}' owner='{{ perlbrew_user }}' mode=0755 state=directory

--- a/tests/playbook.yml
+++ b/tests/playbook.yml
@@ -5,6 +5,17 @@
   become: yes
   vars_files:
     - ./vars.yml
+
+  pre_tasks:
+  - name: Update cache before we get into anything
+    apt:
+      state: latest
+      force_apt_get: true
+      update_cache: true
+      cache_valid_time: 3600
+    become: yes
+    when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+
   roles:
     # it is the directory relative to your current working directory under which the role files are located
     # ./ does not work - why ?


### PR DESCRIPTION
More Ubuntu type updates, I was having grief because my Ubuntu image had an out of date cache, these changes fix that, and document it for others.
As well, we don't change the main role for ansible-perlbrew, just the tests and the Readme.md; there may be cases where somebody doesn't want us updating their build cache but want to use whatever is already setup.